### PR TITLE
Add Google Analytics ID

### DIFF
--- a/qmlcourseRU/_config.yml
+++ b/qmlcourseRU/_config.yml
@@ -15,6 +15,7 @@ html:
   use_repository_button: true
   use_issues_button: true
   baseurl: https://semyonsinchenko.github.io/qmlcourse/_build/html/book/index.html
+  google_analytics_id: UA-51362752-1
 
 notebook_interface: "notebook"
 


### PR DESCRIPTION
Нужно для целей продвижения курса. Добавили GA-метрику.