### PR TITLE
Fix workflow to install psi4 with conda into poetry venv

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       DisableCache:
-        description: 'Disable cache'
+        description: 'disable cache'
         required: false
         default: 'false'
   push:
@@ -18,34 +18,40 @@ jobs:
       TF_CPP_MIN_LOG_LEVEL: 3
 
     steps:
-      - name: Checkout branch for build
+      - name: checkout branch for build
         uses: actions/checkout@v2
 
-      - name: Checkout branch with cache
+      - name: checkout branch with cache
         uses: actions/checkout@v2
         with:
           ref: "gh-pages"
           path: ./gh-pages
 
-      - name: Copy cache for build book
+      - name: copy cache for build book
         if: ${{ github.event.inputs.DisableCache != 'true' }}
         run: |
           cp -r ./gh-pages/_build/ ./qmlcourseRU/ || exit 0
 
-      # Install dependencies
-      - name: Set up Python 3.8
+      - name: set up Python 3.8
         uses: actions/setup-python@v2.2.2
         with:
           python-version: 3.8
 
-      - name: Set up poetry
+      - name: set up conda
+        uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          python-version: 3.8
+          conda-channels: anaconda, conda-forge, psi4
+          activate-conda: true
+
+      - name: set up poetry
         uses: snok/install-poetry@v1.1.6
         with:
-          virtualenvs-create: true
+          virtualenvs-create: false
           virtualenvs-in-project: true
 
-      #Use cache
-      - name: Copy cache dir for dependecies
+      - name: copy cache dir for dependecies
         uses: actions/cache@v2
         env:
           cache-name: cache-poetry-modules
@@ -53,8 +59,11 @@ jobs:
           path: .venv
           key: venv2-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
-      - name: Install dependencies
+      - name: install the main dependencies
         run: |
+          conda create python=3.8 -p .venv -y
+          conda install psi4 -c psi4 -p .venv -y
+
           poetry install
 
       # todo: replace with a more sane solution
@@ -72,12 +81,11 @@ jobs:
         run: |
           export DWAVE_TOKEN="$DWAVE_TOKEN"
 
-      - name: Build the book
+      - name: build the book
         run: |
           poetry run jupyter-book build ./qmlcourseRU
 
-      # Push the book's HTML to github-pages
-      - name: GitHub Pages action
+      - name: gh-pages action
         uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  deploy_branch_aws:
+  deploy_branch:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -12,17 +12,15 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
 
-      # Another magic action
       - name: get branch name
         uses: nelonoel/branch-name@v1.0.1
 
-      # Set up PY38
-      - name: Set up Python 3.8
+      - name: set up Python 3.8
         uses: actions/setup-python@v2.2.2
         with:
           python-version: 3.8
 
-      - name: Set up conda
+      - name: set up conda
         uses: s-weigand/setup-conda@v1
         with:
           update-conda: true
@@ -30,18 +28,17 @@ jobs:
           conda-channels: anaconda, conda-forge, psi4
           activate-conda: true
 
-      # Set up POETRY
-      - name: Set up poetry
+      - name: set up poetry
         uses: snok/install-poetry@v1.1.6
         with:
           virtualenvs-create: false
           virtualenvs-in-project: true
 
-      # Install dependencies
-      - name: Install dependencies
+      - name: install the main dependencies
         run: |
           conda create python=3.8 -p .venv -y
           conda install psi4 -c psi4 -p .venv -y
+
           poetry install
 
       # todo: replace with a more sane solution

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -22,16 +22,26 @@ jobs:
         with:
           python-version: 3.8
 
+      - name: Set up conda
+        uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          python-version: 3.8
+          conda-channels: anaconda, conda-forge, psi4
+          activate-conda: true
+
       # Set up POETRY
       - name: Set up poetry
         uses: snok/install-poetry@v1.1.6
         with:
-          virtualenvs-create: true
+          virtualenvs-create: false
           virtualenvs-in-project: true
 
       # Install dependencies
       - name: Install dependencies
         run: |
+          conda create python=3.8 -p .venv -y
+          conda install psi4 -c psi4 -p .venv -y
           poetry install
 
       # todo: replace with a more sane solution

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
 
 jobs:
+
   deploy_branch:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/qmlcourseRU/book/problemsblock/quantchemadvancedscf.md
+++ b/qmlcourseRU/book/problemsblock/quantchemadvancedscf.md
@@ -165,6 +165,8 @@ $$
 
 ```{code-cell} ipython3
 import psi4
+psi4.core.be_quiet() # отключаем логирование в stdout
+
 
 h_atom = psi4.geometry("H")
 ```

--- a/qmlcourseRU/book/problemsblock/quantchemadvancedscf.md
+++ b/qmlcourseRU/book/problemsblock/quantchemadvancedscf.md
@@ -167,7 +167,6 @@ $$
 import psi4
 psi4.core.be_quiet() # отключаем логирование в stdout
 
-
 h_atom = psi4.geometry("H")
 ```
 


### PR DESCRIPTION
Попытка встроить psi4 

### Как должен работать фикс
При исользовании в конфиге poetry virtualenvs-in-project:true, виртуальное окружение по умолчанию создается и читается из `<project>/.venv/` . При этом и poetry может работать с любым venv, не обязательно созданными ей самостоятельно.
Фикс создает в .venv виртуальное окружение через conda и устанавливает туда psi4.
Дальше poetry распознает этот .venv как собственный и при `poetry install` устанавливает туда зависимости.

### Тесты
Трюк работает у меня локально на linux, и сработал в моих [actions](https://github.com/zimka/qmlcourse.ai/runs/4344297183?check_suite_focus=true#step:9:1164): я добавил в конец workflow дополнительно cat собранной лекции с psi4, и в ней есть `output stream`, т.е. код лекции был успешно прогнан.


